### PR TITLE
Removed InVidio.us URL

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,8 +3,6 @@
   "version": "1.7.2",
   "permissions": [
     "https://www.youtube.com/",
-    "https://invidio.us/channel/*",
-    "https://invidio.us/watch?v=*",
     "https://api.lbry.com/*",
     "https://lbry.tv/*",
     "tabs",


### PR DESCRIPTION
Removed the invidio.us urls from permissions. Invidio.us shutdown back in September 1, 2020.