### PR TITLE
Handles CSV file type for subscriptions

### DIFF
--- a/src/common/yt.ts
+++ b/src/common/yt.ts
@@ -77,6 +77,18 @@ export const ytService = {
   },
 
   /**
+   * Reads an array of YT channel IDs from the YT subscriptions CSV file
+   *
+   * @param jsonContents a CSV file as a string
+   * @returns the channel IDs
+   */
+   readCsv(csvContents: string): string[] {
+     const [,...subscriptions] = csvContents.trim().split('\n').map(line => line.split(',')[0])
+     return subscriptions;
+  },
+
+
+  /**
    * Extracts the channelID from a YT URL.
    *
    * Handles these two types of YT URLs:

--- a/src/tools/YTtoLBRY.tsx
+++ b/src/tools/YTtoLBRY.tsx
@@ -15,8 +15,18 @@ import readme from './README.md';
 async function lbryChannelsFromFile(file: File) {
   const ext = file.name.split('.').pop()?.toLowerCase();
   const content = await getFileContent(file);
+  const ids = new Set((() => {
+    switch(ext) {
+      case 'xml':
+      case 'opml':
+        return ytService.readOpml(content)
+      case 'json':
+        return ytService.readJson(content)
+      case 'csv':
+        return ytService.readCsv(content)
+    }
+  })())
 
-  const ids = new Set((ext === 'xml' || ext == 'opml' ? ytService.readOpml(content) : ytService.readJson(content)))
   const lbryUrls = await ytService.resolveById(...Array.from(ids).map(id => ({ id, type: 'channel' } as const)));
   const { redirect } = await getSettingsAsync('redirect');
   const urlPrefix = redirectDomains[redirect].prefix;


### PR DESCRIPTION
Google Takeout now exports subscription in a CSV format as described in https://github.com/kodxana/Watch-on-Odysee/issues/18, https://github.com/kodxana/Watch-on-Odysee/issues/15 and https://github.com/kodxana/Watch-on-Odysee/issues/13

This PR fix this by adding a function that extract channels ids from the csv generated by Google Takeout while keeping the compatibility with opml, xml and json