### PR TITLE
Prevent unwanted errors when ctx does not exist

### DIFF
--- a/src/scripts/ytContent.tsx
+++ b/src/scripts/ytContent.tsx
@@ -1,8 +1,6 @@
 import { h, JSX, render } from 'preact';
 
-import { parseProtocolUrl } from '../common/lbry-url';
 import { LbrySettings, redirectDomains } from '../common/settings';
-import { YTDescriptor, ytService } from '../common/yt';
 import { UpdateContext } from './tabOnUpdated';
 
 interface UpdaterOptions {

--- a/src/scripts/ytContent.tsx
+++ b/src/scripts/ytContent.tsx
@@ -32,13 +32,6 @@ function openApp(url: string) {
   location.assign(url);
 }
 
-async function resolveYT(descriptor: YTDescriptor) {
-  const lbryProtocolUrl: string | null = await ytService.resolveById(descriptor).then(a => a[0]);
-  const segments = parseProtocolUrl(lbryProtocolUrl || '', { encode: true });
-  if (segments.length === 0) return;
-  return segments.join('/');
-}
-
 /** Compute the URL and determine whether or not a redirect should be performed. Delegates the redirect to callbacks. */
 async function handleURLChange(ctx: UpdateContext, { onRedirect, onURL }: UpdaterOptions): Promise<void> {
   if (onURL) onURL(ctx);


### PR DESCRIPTION
- Check for existence of `ctx` before destructuring since `ctxFromURL` can return `undefined` (cf: partial error below)
This happens on first load on root youtube page (https://www.youtube.com) or on page that are not video/watch page (eg: https://www.youtube.com/feed/channels)
- Also removes unused import and function in `ytContent.tsx`

```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'descriptor')
    at ytContent.js:5138
    at Generator.next (<anonymous>)
    at ytContent.js:4995
    at new Promise (<anonymous>)
    at __awaiter (ytContent.js:4974)
    at onURL (ytContent.js:5128)
    at ytContent.js:5058
    at Generator.next (<anonymous>)
    at ytContent.js:4995
    at new Promise (<anonymous>)
(anonymous) @ ytContent.js:5138
(anonymous) @ ytContent.js:4995
__awaiter @ ytContent.js:4974
onURL @ ytContent.js:5128
(anonymous) @ ytContent.js:5058
(anonymous) @ ytContent.js:4995
__awaiter @ ytContent.js:4974
handleURLChange @ ytContent.js:5056
handle @ ytContent.js:5126
(anonymous) @ ytContent.js:5164
(anonymous) @ ytContent.js:4995
__awaiter @ ytContent.js:4974
(anonymous) @ ytContent.js:5163
ytContent.js:5059 
        
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'enabled')
    at ytContent.js:5059
    at Generator.next (<anonymous>)
    at ytContent.js:4995
    at new Promise (<anonymous>)
    at __awaiter (ytContent.js:4974)
    at handleURLChange (ytContent.js:5056)
    at handle (ytContent.js:5126)
    at ytContent.js:5164
    at Generator.next (<anonymous>)
    at ytContent.js:4995
(anonymous) @ ytContent.js:5059
(anonymous) @ ytContent.js:4995
__awaiter @ ytContent.js:4974
handleURLChange @ ytContent.js:5056
handle @ ytContent.js:5126
(anonymous) @ ytContent.js:5164
(anonymous) @ ytContent.js:4995
__awaiter @ ytContent.js:4974
(anonymous) @ ytContent.js:5163
```