### PR TITLE
Remove tabs permission from manifest.v2.json

### DIFF
--- a/manifest.v2.json
+++ b/manifest.v2.json
@@ -18,7 +18,6 @@
         "https://odysee.com/",
         "https://madiator.com/",
         "https://finder.madiator.com/",
-        "tabs",
         "storage"
     ],
     "web_accessible_resources": [


### PR DESCRIPTION
## Summary
- remove unused `tabs` permission from the v2 manifest to reduce required privileges